### PR TITLE
Fix some -Wsign-compare warnings in tests.

### DIFF
--- a/test/derive_lane_s_routes_test.cc
+++ b/test/derive_lane_s_routes_test.cc
@@ -33,8 +33,8 @@ namespace {
 class DragwayBasedRouteTest : public DragwayBasedTest {
  protected:
   void CheckRoutes(const std::vector<LaneSRoute>& routes, const LaneSRange& expected_range) {
-    ASSERT_EQ(routes.size(), 1);
-    ASSERT_EQ(routes.at(0).ranges().size(), 1);
+    ASSERT_EQ(routes.size(), 1u);
+    ASSERT_EQ(routes.at(0).ranges().size(), 1u);
     const LaneSRange& range = routes.at(0).ranges().at(0);
     ASSERT_EQ(range.lane_id(), expected_range.lane_id());
     ASSERT_EQ(range.s_range().s0(), expected_range.s_range().s0());
@@ -82,14 +82,14 @@ TEST_F(DragwayBasedRouteTest, CrossLaneTests) {
   for (const auto& test_case : test_cases) {
     const RoadPosition start(test_case.start_lane, LanePosition(0, 0, 0));
     const RoadPosition end(test_case.end_lane, LanePosition(kLength, 0, 0));
-    ASSERT_EQ(DeriveLaneSRoutes(start, end, kLength).size(), 0);
+    ASSERT_EQ(DeriveLaneSRoutes(start, end, kLength).size(), 0u);
   }
 }
 
 namespace {
 
 void CheckRoutes(const std::vector<LaneSRoute>& routes, const std::vector<LaneSRange>& expected_route) {
-  ASSERT_EQ(routes.size(), 1);
+  ASSERT_EQ(routes.size(), 1u);
   const std::vector<LaneSRange>& ranges = routes.at(0).ranges();
   ASSERT_EQ(ranges.size(), expected_route.size());
   for (size_t i = 0; i < ranges.size(); ++i) {
@@ -144,7 +144,7 @@ TEST_F(BranchAndMergeBasedTest, NoContinuousSPath) {
   const Lane* end_lane = index_.GetLane(LaneId("l:3_1"));
   const RoadPosition start(start_lane, LanePosition(0, 0, 0));
   const RoadPosition end(end_lane, LanePosition(end_lane->length(), 0, 0));
-  ASSERT_EQ(DeriveLaneSRoutes(start, end, total_length_).size(), 0);
+  ASSERT_EQ(DeriveLaneSRoutes(start, end, total_length_).size(), 0u);
 }
 
 // Verifies DeriveLaneSRoutes() doesn't enter an infinite loop.
@@ -156,7 +156,7 @@ TEST_F(LoopBasedTest, DeriveLaneSRoutesNoInfiniteLoop) {
   const RoadPosition start(start_lane, LanePosition(0, 0, 0));
   const RoadPosition end(end_lane, LanePosition(end_lane->length(), 0, 0));
   const std::vector<LaneSRoute> routes = DeriveLaneSRoutes(start, end, kMaxLength);
-  ASSERT_EQ(routes.size(), 5);
+  ASSERT_EQ(routes.size(), 5u);
 }
 
 // Verifies DeriveLaneSRoutes() can handle start / end positions that are in the

--- a/test/find_lane_sequences_test.cc
+++ b/test/find_lane_sequences_test.cc
@@ -115,7 +115,7 @@ TEST_F(LoopBasedTest, FindLaneSequencesTest) {
   const Lane* start_lane = index_.GetLane(LaneId("l:0_0"));
   const Lane* end_lane = index_.GetLane(LaneId("l:4_0"));
   const std::vector<std::vector<const Lane*>> sequences = FindLaneSequences(start_lane, end_lane, kMaxLength);
-  ASSERT_EQ(sequences.size(), 5);
+  ASSERT_EQ(sequences.size(), 5u);
 }
 
 TEST_F(MultiBranchBasedTest, FindLaneSequencesTest) {
@@ -137,7 +137,7 @@ GTEST_TEST(FindLaneSequencesTest, NoRouteToEndLane) {
       maliput::common::Filesystem::get_env_path(MULTILANE_RESOURCE_VAR) + "/dual_non_intersecting_lanes.yaml");
   const Lane* start_lane = road->junction(0)->segment(0)->lane(0);
   const Lane* end_lane = road->junction(1)->segment(0)->lane(0);
-  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, start_lane->length() + end_lane->length()).size(), 0);
+  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, start_lane->length() + end_lane->length()).size(), 0u);
 }
 
 GTEST_TEST(FindLaneSequencesTest, MaxLengthOmitsStartAndEndLanes) {
@@ -148,10 +148,10 @@ GTEST_TEST(FindLaneSequencesTest, MaxLengthOmitsStartAndEndLanes) {
   const Lane* start_lane = index.GetLane(LaneId("l:0_0"));
   const Lane* middle_lane = index.GetLane(LaneId("l:1_0"));
   const Lane* end_lane = index.GetLane(LaneId("l:2_0"));
-  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, middle_lane->length() / 2).size(), 0);
-  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, middle_lane->length()).size(), 1);
+  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, middle_lane->length() / 2).size(), 0u);
+  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, middle_lane->length()).size(), 1u);
   const double total_length = start_lane->length() + middle_lane->length() + end_lane->length();
-  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, total_length).size(), 1);
+  ASSERT_EQ(FindLaneSequences(start_lane, end_lane, total_length).size(), 1u);
 }
 
 }  // namespace routing

--- a/test/intersection_book_loader_test.cc
+++ b/test/intersection_book_loader_test.cc
@@ -67,7 +67,7 @@ TEST_F(TestLoading2x2IntersectionIntersectionBook, LoadFromFile) {
   EXPECT_TRUE(intersection->Phase().has_value());
   EXPECT_EQ(intersection->Phase()->state, Phase::Id("NorthSouthPhase"));
   EXPECT_TRUE(intersection->Phase()->next.has_value());
-  EXPECT_GT(intersection->region().size(), 0);
+  EXPECT_GT(intersection->region().size(), 0u);
   EXPECT_EQ(intersection->ring_id(), PhaseRing::Id("2x2Intersection"));
 }
 

--- a/test/road_rulebook_loader_test.cc
+++ b/test/road_rulebook_loader_test.cc
@@ -245,7 +245,7 @@ class TestLoading2x2IntersectionRules : public ::testing::Test {
         rulebook->GetDiscreteValueRule(GetRuleIdFrom(VehicleStopInZoneBehaviorRuleTypeId(), right_of_way_rule.id()));
     // Compare values.
     EXPECT_DOUBLE_EQ(vehicle_stop_in_zone_discrete_rule.zone().length(), right_of_way_rule.zone().length());
-    EXPECT_EQ(vehicle_stop_in_zone_discrete_rule.values().size(), 1);
+    EXPECT_EQ(vehicle_stop_in_zone_discrete_rule.values().size(), 1u);
     EXPECT_EQ(vehicle_stop_in_zone_discrete_rule.values()[0].severity, Rule::State::kStrict);
     EXPECT_TRUE(vehicle_stop_in_zone_discrete_rule.values()[0].related_rules.empty());
     if (right_of_way_rule.zone_type() == RightOfWayRule::ZoneType::kStopExcluded) {
@@ -280,7 +280,7 @@ class TestLoading2x2IntersectionRules : public ::testing::Test {
     }
 
     // Check the related unique ids of the discrete value.
-    int related_bulb_group_size{0};
+    unsigned int related_bulb_group_size{0};
     for (const auto& traffic_light_id_vector_bulb_group_id : right_of_way_rule.related_bulb_groups()) {
       related_bulb_group_size += traffic_light_id_vector_bulb_group_id.second.size();
     }

--- a/test/waypoints_test.cc
+++ b/test/waypoints_test.cc
@@ -80,8 +80,8 @@ GTEST_TEST(WaypointsTest, Waypoints) {
                                               GeoPosition(9.0, 0.0, 0.0), GeoPosition(13.0, 0.0, 0.0),
                                               GeoPosition(15.0, 0.0, 0.0)};
 
-  ASSERT_EQ(waypoints.size(), 5);
-  for (int i = 0; i < waypoints.size(); ++i) {
+  ASSERT_EQ(waypoints.size(), 5u);
+  for (unsigned int i = 0; i < waypoints.size(); ++i) {
     EXPECT_TRUE(api::test::IsGeoPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance));
   }
 
@@ -99,8 +99,8 @@ GTEST_TEST(WaypointsTest, Waypoints) {
       GeoPosition(5.0, 0.0, 0.0),
       GeoPosition(7.0, 0.0, 0.0),
   };
-  ASSERT_EQ(waypoints.size(), 2);
-  for (int i = 0; i < waypoints.size(); ++i) {
+  ASSERT_EQ(waypoints.size(), 2u);
+  for (unsigned int i = 0; i < waypoints.size(); ++i) {
     EXPECT_TRUE(api::test::IsGeoPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance));
   }
 
@@ -119,8 +119,8 @@ GTEST_TEST(WaypointsTest, Waypoints) {
       GeoPosition(kLinearTolerance, 0.0, 0.0),
   };
   waypoints = rg->SampleAheadWaypoints(route_with_linear_tolerance_lane, step_smaller_than_linear_tolerance);
-  EXPECT_EQ(waypoints.size(), 2);
-  for (int i = 0; i < waypoints.size(); ++i) {
+  EXPECT_EQ(waypoints.size(), 2u);
+  for (unsigned int i = 0; i < waypoints.size(); ++i) {
     EXPECT_TRUE(api::test::IsGeoPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance));
   }
 };


### PR DESCRIPTION
I'm not sure why these started appearing recently, but they are easy enough to fix.