### PR TITLE
Use GitHub Actions CI to build and test with gcc

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -1,0 +1,9 @@
+repositories:
+  ament_cmake_doxygen:
+    type: git
+    url: https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen
+    version: master
+  pybind11:
+    type: git
+    url: https://github.com/RobotLocomotion/pybind11.git
+    version: 69a5d92a5ff9fe84581a1edeb6051a8c21d9eb97

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Compile and test
+
+on: [push, pull_request]
+
+env:
+  PACKAGE_NAME: maliput_integration_tests
+  ROS_DISTRO: dashing
+  ROS_WS: maliput_ws
+
+jobs:
+  compile_and_test:
+    name: Compile and test
+    runs-on: ubuntu-18.04
+    container:
+      image: ubuntu:18.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
+    # clone private dependencies
+    - uses: actions/checkout@v2
+      with:
+        repository: ToyotaResearchInstitute/maliput
+        path: ${{ env.ROS_WS }}/src/maliput
+        token: ${{ secrets.MALIPUT_TOKEN }}
+    - uses: actions/checkout@v2
+      with:
+        repository: ToyotaResearchInstitute/maliput-dragway
+        path: ${{ env.ROS_WS }}/src/maliput_dragway
+        token: ${{ secrets.MALIPUT_TOKEN }}
+    - uses: actions/checkout@v2
+      with:
+        repository: ToyotaResearchInstitute/maliput-multilane
+        path: ${{ env.ROS_WS }}/src/maliput_multilane
+        token: ${{ secrets.MALIPUT_TOKEN }}
+    - uses: actions/checkout@v2
+      with:
+        repository: ToyotaResearchInstitute/drake-vendor
+        path: ${{ env.ROS_WS }}/src/drake_vendor
+        token: ${{ secrets.MALIPUT_TOKEN }}
+    - uses: actions/checkout@v2
+      with:
+        repository: ToyotaResearchInstitute/dsim-repos-index
+        path: dsim-repos-index
+        token: ${{ secrets.MALIPUT_TOKEN }}
+    # use setup-ros action to get vcs, rosdep, and colcon
+    - uses: ros-tooling/setup-ros@0.0.25
+    # install drake_vendor prereqs using dsim-repos-index/tools/prereqs.lib
+    - name: install drake_vendor prereqs
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}/src/drake_vendor
+      run: ${GITHUB_WORKSPACE}/dsim-repos-index/tools/prereqs-install -t drake .
+    # clone public dependencies
+    - name: vcs import
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
+    - run: colcon graph
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+    - name: rosdep install
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: |
+        rosdep update;
+        rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
+    - name: colcon build
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: |
+        . /opt/ros/${ROS_DISTRO}/setup.bash;
+        colcon build --packages-up-to ${PACKAGE_NAME} --event-handlers=console_direct+;
+    - name: colcon test
+      shell: bash
+      working-directory: ${{ env.ROS_WS }}
+      run: |
+        . /opt/ros/${ROS_DISTRO}/setup.bash;
+        colcon test --packages-select ${PACKAGE_NAME} --event-handlers=console_direct+;
+        colcon test-result --verbose;


### PR DESCRIPTION
* Use the `ros-tooling/setup-ros` action to install build tools on an `ubuntu-18.04` worker.

* Add a `dependencies.repos` file and use `vcs import` to checkout public dependencies into a colcon workspace.

* Use `actions/checkout@v2` to checkout private dependencies using the `MALIPUT_TOKEN` secret.

* Use rosdep to install dependencies, then `colcon build` and `colcon test`.