### PR TITLE
Restores scan-build workflow on label

### DIFF
--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -1,10 +1,8 @@
 name: scan_build
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
+    types: [labeled]
 
 env:
   PACKAGE_NAME: maliput_integration_tests
@@ -13,6 +11,7 @@ env:
 
 jobs:
   static_analysis:
+    if: contains(github.event.pull_request.labels.*.name, 'do-static-analyzer-test')
     name: Static analysis
     runs-on: ubuntu-18.04
     container:


### PR DESCRIPTION
Part of ToyotaResearchInstitute/dsim-repos-index#177

Restores scan-build workflow only when `do-static-analyzer-test` label is added.