### PR TITLE
Use maliput_drake instead of drake_vendor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,9 +67,9 @@ jobs:
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/drake-vendor
+        repository: ToyotaResearchInstitute/maliput_drake
         fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/drake_vendor
+        path: ${{ env.ROS_WS }}/src/maliput_drake
         token: ${{ secrets.MALIPUT_TOKEN }}
     - name: check if dependencies have a matching branch
       shell: bash
@@ -89,10 +89,6 @@ jobs:
       run: |
         rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
-    - name: install drake
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}/src/drake_vendor
-      run: ./drake_installer
     - name: colcon build
       shell: bash
       working-directory: ${{ env.ROS_WS }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -66,9 +66,9 @@ jobs:
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/drake-vendor
+        repository: ToyotaResearchInstitute/maliput_drake
         fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/drake_vendor
+        path: ${{ env.ROS_WS }}/src/maliput_drake
         token: ${{ secrets.MALIPUT_TOKEN }}
     - name: check if dependencies have a matching branch
       shell: bash
@@ -91,10 +91,6 @@ jobs:
       run: |
         rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
-    - name: install drake
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}/src/drake_vendor
-      run: ./drake_installer
     - name: colcon build
       shell: bash
       working-directory: ${{ env.ROS_WS }}

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -55,9 +55,9 @@ jobs:
         token: ${{ secrets.MALIPUT_TOKEN }}
     - uses: actions/checkout@v2
       with:
-        repository: ToyotaResearchInstitute/drake-vendor
+        repository: ToyotaResearchInstitute/maliput_drake
         fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/drake_vendor
+        path: ${{ env.ROS_WS }}/src/maliput_drake
         token: ${{ secrets.MALIPUT_TOKEN }}
     - name: check if dependencies have a matching branch
       shell: bash
@@ -80,10 +80,6 @@ jobs:
       run: |
         rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
-    - name: install drake
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}/src/drake_vendor
-      run: ./drake_installer
     - name: colcon build up-to
       shell: bash
       working-directory: ${{ env.ROS_WS }}


### PR DESCRIPTION
Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/232


Points CI to use maliput_drake instead of drake_vendor.