### PR TITLE
Removes maliput_drake from CI.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -11,10 +11,6 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput_py
     version: main
-  maliput_drake:
-    type: git
-    url: https://github.com/maliput/maliput_drake
-    version: main
   maliput_dragway:
     type: git
     url: https://github.com/maliput/maliput_dragway


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_infrastructure/issues/309

:exclamation: :star2:  This PR needs to be merged in sync with others!

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/4610de7ad2353458413457bb71e71580/raw/965be0c4969e72ca428980453c6096958deae8fe/maliput_integration_tests.repos

