### PR TITLE
Uses compare methods instead of maliput test_utilities.

### DIFF
--- a/test/assert_compare.h
+++ b/test/assert_compare.h
@@ -1,0 +1,46 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <gtest/gtest.h>
+#include <maliput/common/compare.h>
+
+namespace maliput {
+namespace test {
+
+template <typename T>
+::testing::AssertionResult AssertCompare(const maliput::common::ComparisonResult<T>& res) {
+  if (!res.message.has_value()) {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure() << res.message.value();
+}
+
+}  // namespace test
+}  // namespace maliput

--- a/test/phase_ring_book_loader_test.cc
+++ b/test/phase_ring_book_loader_test.cc
@@ -40,6 +40,7 @@
 
 #include <gtest/gtest.h>
 #include <maliput/api/road_geometry.h>
+#include <maliput/api/rules/compare.h>
 #include <maliput/api/rules/phase.h>
 #include <maliput/api/rules/phase_ring.h>
 #include <maliput/api/rules/right_of_way_rule.h>
@@ -48,10 +49,10 @@
 #include <maliput/base/rule_registry.h>
 #include <maliput/base/traffic_light_book_loader.h>
 #include <maliput/common/filesystem.h>
-#include <maliput/test_utilities/phases_compare.h>
-#include <maliput/test_utilities/rules_test_utilities.h>
 #include <maliput_multilane/builder.h>
 #include <maliput_multilane/loader.h>
+
+#include "assert_compare.h"
 
 namespace maliput {
 namespace test {
@@ -403,13 +404,14 @@ TEST_F(TestLoading2x2IntersectionPhasebook, LoadFromFile) {
   EXPECT_EQ(phases.size(), expected_phases_.size());
 
   for (const auto& expected_phase : expected_phases_) {
-    EXPECT_TRUE(MALIPUT_IS_EQUAL(expected_phase, phases.at(expected_phase.id())));
+    EXPECT_TRUE(AssertCompare(api::rules::IsEqual(expected_phase, phases.at(expected_phase.id()))));
   }
 
   const std::unordered_map<Phase::Id, std::vector<PhaseRing::NextPhase>>& next_phases = ring->next_phases();
   EXPECT_EQ(next_phases.size(), expected_next_phases_.size());
   for (const auto& expected_next_phase : expected_next_phases_) {
-    EXPECT_TRUE(MALIPUT_IS_EQUAL(expected_next_phase.second, next_phases.at(expected_next_phase.first)));
+    EXPECT_TRUE(
+        AssertCompare(api::rules::IsEqual(expected_next_phase.second, next_phases.at(expected_next_phase.first))));
   }
 }
 

--- a/test/traffic_light_book_loader_test.cc
+++ b/test/traffic_light_book_loader_test.cc
@@ -36,14 +36,15 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <maliput/api/rules/compare.h>
 #include <maliput/api/rules/traffic_light_book.h>
 #include <maliput/api/rules/traffic_lights.h>
 #include <maliput/common/filesystem.h>
 #include <maliput/math/quaternion.h>
-#include <maliput/test_utilities/rules_test_utilities.h>
-#include <maliput/test_utilities/traffic_lights_compare.h>
 #include <maliput_multilane/builder.h>
 #include <maliput_multilane/loader.h>
+
+#include "assert_compare.h"
 
 namespace maliput {
 namespace {
@@ -58,6 +59,8 @@ using api::rules::BulbType;
 using api::rules::TrafficLight;
 using api::rules::TrafficLightBook;
 using api::rules::UniqueBulbId;
+using maliput::api::rules::IsEqual;
+using maliput::test::AssertCompare;
 
 static constexpr char kMultilaneResourcesPath[] = DEF_MULTILANE_RESOURCES;
 
@@ -99,7 +102,7 @@ TEST_F(TestLoading2x2IntersectionTrafficLightbook, LoadFromFile) {
   EXPECT_NE(book, nullptr);
   const TrafficLight* south_facing = book->GetTrafficLight(TrafficLight::Id("SouthFacing"));
   EXPECT_NE(south_facing, nullptr);
-  EXPECT_TRUE(MALIPUT_IS_EQUAL(south_facing, south_facing_.get()));
+  EXPECT_TRUE(AssertCompare(IsEqual(south_facing, south_facing_.get())));
   for (const auto& name : {"NorthFacing", "EastFacing", "WestFacing"}) {
     EXPECT_NE(book->GetTrafficLight(TrafficLight::Id(name)), nullptr);
   }

--- a/test/waypoints_test.cc
+++ b/test/waypoints_test.cc
@@ -33,15 +33,17 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/regions.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/common/assertion_error.h>
 #include <maliput/common/filesystem.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 #include <maliput_multilane/builder.h>
 #include <maliput_multilane/loader.h>
+
+#include "assert_compare.h"
 
 namespace maliput {
 namespace {
@@ -52,6 +54,8 @@ using api::LanePosition;
 using api::LaneSRange;
 using api::LaneSRoute;
 using api::RoadGeometry;
+using maliput::api::IsEqual;
+using maliput::test::AssertCompare;
 
 GTEST_TEST(WaypointsTest, Waypoints) {
   const std::string kId = "long_start_and_end_lanes";
@@ -114,7 +118,7 @@ GTEST_TEST(WaypointsTest, Waypoints) {
 
   ASSERT_EQ(waypoints.size(), 5u);
   for (unsigned int i = 0; i < waypoints.size(); ++i) {
-    EXPECT_TRUE(api::test::IsInertialPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance));
+    EXPECT_TRUE(AssertCompare(IsInertialPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance)));
   }
 
   const LaneSRange shorter_than_sample_step_range_one{lane_one->id(), {5., 5.}};
@@ -133,7 +137,7 @@ GTEST_TEST(WaypointsTest, Waypoints) {
   };
   ASSERT_EQ(waypoints.size(), 2u);
   for (unsigned int i = 0; i < waypoints.size(); ++i) {
-    EXPECT_TRUE(api::test::IsInertialPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance));
+    EXPECT_TRUE(AssertCompare(IsInertialPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance)));
   }
 
   const LaneSRange non_existent_range_lane{LaneId("non-existent"), {0., 2.0}};
@@ -153,7 +157,7 @@ GTEST_TEST(WaypointsTest, Waypoints) {
   waypoints = rg->SampleAheadWaypoints(route_with_linear_tolerance_lane, step_smaller_than_linear_tolerance);
   EXPECT_EQ(waypoints.size(), 2u);
   for (unsigned int i = 0; i < waypoints.size(); ++i) {
-    EXPECT_TRUE(api::test::IsInertialPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance));
+    EXPECT_TRUE(AssertCompare(IsInertialPositionClose(waypoints[i], expected_waypoints[i], kLinearTolerance)));
   }
 };
 


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/issues/602

## Summary
 - Do not use `maliput::test_utilities`'s compare methods.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
