### PR TITLE
Adds a test to evaluate FindLaneSequences() removing sequences with U-turns.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ macro(add_dependencies_to_test target)
         maliput_dragway::maliput_dragway
         maliput_dragway::maliput_dragway_test_utilities
         maliput_malidrive::builder
+        maliput_malidrive::loader
         maliput_multilane::maliput_multilane
         maliput_multilane::test_utilities)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/maliput/maliput/issues/614

## Summary

Adds a test to the overload of `maliput::routing::FindLaneSequences()` using the `remove_u_turns` flag.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.


ros-action-ci-repos-override: https://gist.github.com/agalbachicar/agalbachicar_614_find_lane_sequences.repos